### PR TITLE
Propagate json error object to the caller

### DIFF
--- a/pkg/plugin/types.go
+++ b/pkg/plugin/types.go
@@ -17,6 +17,7 @@ package plugin
 import (
 	"encoding/json"
 	"net"
+	"os"
 
 	"github.com/appc/cni/pkg/ip"
 )
@@ -36,6 +37,10 @@ type Result struct {
 	IP6 *IPConfig `json:"ip6,omitempty"`
 }
 
+func (r *Result) Print() error {
+	return prettyPrint(r)
+}
+
 // IPConfig contains values necessary to configure an interface
 type IPConfig struct {
 	IP      net.IPNet
@@ -52,6 +57,14 @@ type Error struct {
 	Code    uint   `json:"code"`
 	Msg     string `json:"msg"`
 	Details string `json:"details,omitempty"`
+}
+
+func (e *Error) Error() string {
+	return e.Msg
+}
+
+func (e *Error) Print() error {
+	return prettyPrint(e)
 }
 
 // net.IPNet is not JSON (un)marshallable so this duality is needed
@@ -109,4 +122,13 @@ func (r *Route) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(rt)
+}
+
+func prettyPrint(obj interface{}) error {
+	data, err := json.MarshalIndent(obj, "", "    ")
+	if err != nil {
+		return err
+	}
+	_, err = os.Stdout.Write(data)
+	return err
 }

--- a/plugins/ipam/dhcp/main.go
+++ b/plugins/ipam/dhcp/main.go
@@ -45,7 +45,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("error calling DHCP.Add: %v", err)
 	}
 
-	return plugin.PrintResult(result)
+	return result.Print()
 }
 
 func cmdDel(args *skel.CmdArgs) error {

--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -59,9 +59,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	return plugin.PrintResult(&plugin.Result{
+	r := &plugin.Result{
 		IP4: ipConf,
-	})
+	}
+	return r.Print()
 }
 
 func cmdDel(args *skel.CmdArgs) error {

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -221,7 +221,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	return plugin.PrintResult(result)
+	return result.Print()
 }
 
 func cmdDel(args *skel.CmdArgs) error {

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -145,7 +145,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	return plugin.PrintResult(result)
+	return result.Print()
 }
 
 func cmdDel(args *skel.CmdArgs) error {

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -149,7 +149,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	return plugin.PrintResult(result)
+	return result.Print()
 }
 
 func cmdDel(args *skel.CmdArgs) error {

--- a/plugins/main/veth/veth.go
+++ b/plugins/main/veth/veth.go
@@ -121,7 +121,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	return plugin.PrintResult(result)
+	return result.Print()
 }
 
 func cmdDel(args *skel.CmdArgs) error {

--- a/scripts/exec-plugins.sh
+++ b/scripts/exec-plugins.sh
@@ -16,9 +16,14 @@ function exec_plugins() {
 		plugin=$(jq -r '.type' <$netconf)
 		export CNI_IFNAME=$(printf eth%d $i)
 
-		$plugin <$netconf >/dev/null
+		res=$($plugin <$netconf)
 		if [ $? -ne 0 ]; then
-			echo "${name} : error executing $CNI_COMMAND"
+			errmsg=$(echo $res | jq -r '.msg')
+			if [ -z "$errmsg" ]; then
+				errmsg=$res
+			fi
+
+			echo "${name} : error executing $CNI_COMMAND: $errmsg"
 			exit 1
 		fi
 


### PR DESCRIPTION
When plugin errors out, it prints out a JSON object to stdout
describing the failure. This object needs to be propagated out
through the plugins and to the container runtime. This change
also adds Print method to both the result and error structs
for easy serialization to stdout.