### PR TITLE
No more path rewriting

### DIFF
--- a/Godeps/_workspace/src/github.com/d2g/dhcp4client/client.go
+++ b/Godeps/_workspace/src/github.com/d2g/dhcp4client/client.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/d2g/dhcp4"
+	"github.com/d2g/dhcp4"
 )
 
 const (

--- a/Godeps/_workspace/src/github.com/d2g/dhcp4client/pktsock_linux.go
+++ b/Godeps/_workspace/src/github.com/d2g/dhcp4client/pktsock_linux.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/appc/cni/Godeps/_workspace/src/golang.org/x/sys/unix"
+	"golang.org/x/sys/unix"
 )
 
 const (

--- a/Godeps/_workspace/src/github.com/vishvananda/netlink/addr_linux.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netlink/addr_linux.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netlink/nl"
 )
 
 // AddrAdd will add an IP address to a link device.

--- a/Godeps/_workspace/src/github.com/vishvananda/netlink/link_linux.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netlink/link_linux.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netlink/nl"
 )
 
 var native = nl.NativeEndian()

--- a/Godeps/_workspace/src/github.com/vishvananda/netlink/neigh_linux.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netlink/neigh_linux.go
@@ -5,7 +5,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netlink/nl"
 )
 
 const (

--- a/Godeps/_workspace/src/github.com/vishvananda/netlink/netlink.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netlink/netlink.go
@@ -11,7 +11,7 @@ package netlink
 import (
 	"net"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netlink/nl"
 )
 
 const (

--- a/Godeps/_workspace/src/github.com/vishvananda/netlink/protinfo_linux.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netlink/protinfo_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netlink/nl"
 )
 
 func LinkGetProtinfo(link Link) (Protinfo, error) {

--- a/Godeps/_workspace/src/github.com/vishvananda/netlink/route_linux.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netlink/route_linux.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netlink/nl"
 )
 
 // RtAttr is shared so it is in netlink_linux.go

--- a/Godeps/_workspace/src/github.com/vishvananda/netlink/xfrm_policy_linux.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netlink/xfrm_policy_linux.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"syscall"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netlink/nl"
 )
 
 func selFromPolicy(sel *nl.XfrmSelector, policy *XfrmPolicy) {

--- a/Godeps/_workspace/src/github.com/vishvananda/netlink/xfrm_state_linux.go
+++ b/Godeps/_workspace/src/github.com/vishvananda/netlink/xfrm_state_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netlink/nl"
 )
 
 func writeStateAlgo(a *XfrmStateAlgo) []byte {

--- a/Godeps/_workspace/src/golang.org/x/sys/unix/creds_test.go
+++ b/Godeps/_workspace/src/golang.org/x/sys/unix/creds_test.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/appc/cni/Godeps/_workspace/src/golang.org/x/sys/unix"
+	"golang.org/x/sys/unix"
 )
 
 // TestSCMCredentials tests the sending and receiving of credentials

--- a/Godeps/_workspace/src/golang.org/x/sys/unix/mmap_unix_test.go
+++ b/Godeps/_workspace/src/golang.org/x/sys/unix/mmap_unix_test.go
@@ -9,7 +9,7 @@ package unix_test
 import (
 	"testing"
 
-	"github.com/appc/cni/Godeps/_workspace/src/golang.org/x/sys/unix"
+	"golang.org/x/sys/unix"
 )
 
 func TestMmap(t *testing.T) {

--- a/Godeps/_workspace/src/golang.org/x/sys/unix/syscall_bsd_test.go
+++ b/Godeps/_workspace/src/golang.org/x/sys/unix/syscall_bsd_test.go
@@ -9,7 +9,7 @@ package unix_test
 import (
 	"testing"
 
-	"github.com/appc/cni/Godeps/_workspace/src/golang.org/x/sys/unix"
+	"golang.org/x/sys/unix"
 )
 
 const MNT_WAIT = 1

--- a/Godeps/_workspace/src/golang.org/x/sys/unix/syscall_test.go
+++ b/Godeps/_workspace/src/golang.org/x/sys/unix/syscall_test.go
@@ -9,7 +9,7 @@ package unix_test
 import (
 	"testing"
 
-	"github.com/appc/cni/Godeps/_workspace/src/golang.org/x/sys/unix"
+	"golang.org/x/sys/unix"
 )
 
 func testSetGetenv(t *testing.T, key, value string) {

--- a/Godeps/_workspace/src/golang.org/x/sys/unix/syscall_unix_test.go
+++ b/Godeps/_workspace/src/golang.org/x/sys/unix/syscall_unix_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/appc/cni/Godeps/_workspace/src/golang.org/x/sys/unix"
+	"golang.org/x/sys/unix"
 )
 
 // Tests that below functions, structures and constants are consistent

--- a/build
+++ b/build
@@ -9,7 +9,7 @@ if [ ! -h gopath/src/${REPO_PATH} ]; then
 fi
 
 export GOBIN=${PWD}/bin
-export GOPATH=${PWD}/gopath
+export GOPATH=${PWD}/gopath:$(pwd)/Godeps/_workspace
 
 echo "Building plugins"
 

--- a/pkg/ip/ipmasq.go
+++ b/pkg/ip/ipmasq.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/coreos/go-iptables/iptables"
+	"github.com/coreos/go-iptables/iptables"
 )
 
 // SetupIPMasq installs iptables rules to masquerade traffic

--- a/pkg/ip/link.go
+++ b/pkg/ip/link.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink"
 )
 
 func makeVethPair(name, peer string, mtu int) (netlink.Link, error) {

--- a/pkg/ip/route.go
+++ b/pkg/ip/route.go
@@ -17,7 +17,7 @@ package ip
 import (
 	"net"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink"
 )
 
 // AddDefaultRoute sets the default route on the given gateway.

--- a/pkg/plugin/ipam.go
+++ b/pkg/plugin/ipam.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink"
 	"github.com/appc/cni/pkg/ip"
+	"github.com/vishvananda/netlink"
 )
 
 // Find returns the full path of the plugin by searching in CNI_PATH

--- a/plugins/ipam/dhcp/daemon.go
+++ b/plugins/ipam/dhcp/daemon.go
@@ -27,9 +27,9 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/coreos/go-systemd/activation"
 	"github.com/appc/cni/pkg/plugin"
 	"github.com/appc/cni/pkg/skel"
+	"github.com/coreos/go-systemd/activation"
 )
 
 const listenFdsStart = 3

--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -23,9 +23,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/d2g/dhcp4"
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/d2g/dhcp4client"
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink"
+	"github.com/d2g/dhcp4"
+	"github.com/d2g/dhcp4client"
+	"github.com/vishvananda/netlink"
 
 	"github.com/appc/cni/pkg/ns"
 	"github.com/appc/cni/pkg/plugin"

--- a/plugins/ipam/dhcp/options.go
+++ b/plugins/ipam/dhcp/options.go
@@ -20,8 +20,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/d2g/dhcp4"
 	"github.com/appc/cni/pkg/plugin"
+	"github.com/d2g/dhcp4"
 )
 
 func parseRouter(opts dhcp4.Options) net.IP {

--- a/plugins/ipam/dhcp/options_test.go
+++ b/plugins/ipam/dhcp/options_test.go
@@ -18,8 +18,8 @@ import (
 	"net"
 	"testing"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/d2g/dhcp4"
 	"github.com/appc/cni/pkg/plugin"
+	"github.com/d2g/dhcp4"
 )
 
 func validateRoutes(t *testing.T, routes []plugin.Route) {

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -23,11 +23,11 @@ import (
 	"runtime"
 	"syscall"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink"
 	"github.com/appc/cni/pkg/ip"
 	"github.com/appc/cni/pkg/ns"
 	"github.com/appc/cni/pkg/plugin"
 	"github.com/appc/cni/pkg/skel"
+	"github.com/vishvananda/netlink"
 )
 
 const defaultBrName = "cni0"

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink"
 	"github.com/appc/cni/pkg/ip"
 	"github.com/appc/cni/pkg/ns"
 	"github.com/appc/cni/pkg/plugin"
 	"github.com/appc/cni/pkg/skel"
+	"github.com/vishvananda/netlink"
 )
 
 type NetConf struct {

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -21,11 +21,11 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink"
 	"github.com/appc/cni/pkg/ip"
 	"github.com/appc/cni/pkg/ns"
 	"github.com/appc/cni/pkg/plugin"
 	"github.com/appc/cni/pkg/skel"
+	"github.com/vishvananda/netlink"
 )
 
 type NetConf struct {

--- a/plugins/main/veth/veth.go
+++ b/plugins/main/veth/veth.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/appc/cni/Godeps/_workspace/src/github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink"
 
 	"github.com/appc/cni/pkg/ip"
 	"github.com/appc/cni/pkg/ns"


### PR DESCRIPTION
Path rewriting causes too many problems when vendoring
vendored code. When CNI code is vendored into rkt,
godep has problems code already vendored by CNI.