### PR TITLE
ipvlan: wrong name was used during link creation

### DIFF
--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -86,7 +86,7 @@ func createIpvlan(conf *NetConf, ifName string, netns *os.File) error {
 	mv := &netlink.IPVlan{
 		LinkAttrs: netlink.LinkAttrs{
 			MTU:         conf.MTU,
-			Name:        ifName,
+			Name:        tmpName,
 			ParentIndex: m.Attrs().Index,
 			Namespace:   netlink.NsFd(int(netns.Fd())),
 		},


### PR DESCRIPTION
Instead of temp (random) name, the final name (e.g. eth0)
was used during link creation. This would collide on hosts
that already had the an interface with such a name.