### PR TITLE
host-local: allow ip request via CNI_ARGS

### DIFF
--- a/Documentation/host-local.md
+++ b/Documentation/host-local.md
@@ -31,6 +31,11 @@ It stores the state locally on the host filesystem, therefore ensuring uniquenes
 * `gateway` (string, optional): IP inside of "subnet" to designate as the gateway. Defaults to ".1" IP inside of the "subnet" block.
 * `routes` (string, optional): list of routes to add to the container namespace. Each route is a dictionary with "dst" and optional "gw" fields. If "gw" is omitted, value of "gateway" will be used.
 
+## Supported arguments
+The following [CNI_ARGS](https://github.com/appc/cni/blob/master/SPEC.md#parameters) are supported:
+
+* `ip`: request a specific IP address from the subnet. If it's not available, the plugin will exit with an error
+
 ## Files
 
 Allocated IP addresses are stored as files in /var/lib/cni/networks/$NETWORK_NAME.

--- a/pkg/plugin/args.go
+++ b/pkg/plugin/args.go
@@ -1,0 +1,36 @@
+package plugin
+
+import (
+	"encoding"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func LoadArgs(args string, container interface{}) error {
+	if args == "" {
+		return nil
+	}
+
+	containerValue := reflect.ValueOf(container)
+
+	pairs := strings.Split(args, ",")
+	for _, pair := range pairs {
+		kv := strings.Split(pair, "=")
+		if len(kv) != 2 {
+			return fmt.Errorf("ARGS: invalid pair %q", pair)
+		}
+		keyString := kv[0]
+		valueString := kv[1]
+		keyField := containerValue.Elem().FieldByName(keyString)
+		if !keyField.IsValid() {
+			return fmt.Errorf("ARGS: invalid key %q", keyString)
+		}
+		u := keyField.Addr().Interface().(encoding.TextUnmarshaler)
+		err := u.UnmarshalText([]byte(valueString))
+		if err != nil {
+			return fmt.Errorf("ARGS: error parsing value of pair %q: %v)", pair, err)
+		}
+	}
+	return nil
+}

--- a/plugins/ipam/host-local/config.go
+++ b/plugins/ipam/host-local/config.go
@@ -32,6 +32,11 @@ type IPAMConfig struct {
 	Subnet     ip.IPNet       `json:"subnet"`
 	Gateway    net.IP         `json:"gateway"`
 	Routes     []plugin.Route `json:"routes"`
+	Args       *IPAMArgs      `json:"-"`
+}
+
+type IPAMArgs struct {
+	IP net.IP `json:"ip",omitempty`
 }
 
 type Net struct {
@@ -40,10 +45,18 @@ type Net struct {
 }
 
 // NewIPAMConfig creates a NetworkConfig from the given network name.
-func LoadIPAMConfig(bytes []byte) (*IPAMConfig, error) {
+func LoadIPAMConfig(bytes []byte, args string) (*IPAMConfig, error) {
 	n := Net{}
 	if err := json.Unmarshal(bytes, &n); err != nil {
 		return nil, err
+	}
+
+	if args != "" {
+		ipamArgs := IPAMArgs{}
+		err := plugin.LoadArgs(args, &ipamArgs)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if n.IPAM == nil {

--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -28,7 +28,7 @@ func main() {
 }
 
 func cmdAdd(args *skel.CmdArgs) error {
-	ipamConf, err := LoadIPAMConfig(args.StdinData)
+	ipamConf, err := LoadIPAMConfig(args.StdinData, args.Args)
 	if err != nil {
 		return err
 	}
@@ -38,6 +38,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 	defer store.Close()
+
+	ipamArgs := IPAMArgs{}
+	err = plugin.LoadArgs(args.Args, &ipamArgs)
+	if err != nil {
+		return err
+	}
+	ipamConf.Args = &ipamArgs
 
 	allocator, err := NewIPAllocator(ipamConf, store)
 	if err != nil {
@@ -66,7 +73,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 }
 
 func cmdDel(args *skel.CmdArgs) error {
-	ipamConf, err := LoadIPAMConfig(args.StdinData)
+	ipamConf, err := LoadIPAMConfig(args.StdinData, args.Args)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A specific IP can now be requested via the environment variable CNI_ARGS, e.g.
`CNI_ARGS=ip=1.2.3.4`.
The plugin will try to reserve the specified ip.
If this is not successful the execution will fail.

Working on #39.