### PR TITLE
IPAM plugin: improve error messages

### DIFF
--- a/pkg/plugin/ipam.go
+++ b/pkg/plugin/ipam.go
@@ -64,8 +64,8 @@ func ExecAdd(plugin string, netconf []byte) (*Result, error) {
 		return nil, fmt.Errorf("CNI_COMMAND is not ADD")
 	}
 	if plugin == "" {
-		return nil, fmt.Errorf(`Name of IPAM plugin is missing. Specify a "type" field in the "ipam" section`)
-        }
+		return nil, fmt.Errorf(`name of IPAM plugin is missing. Please specify a "type" field in the "ipam" section`)
+	}
 
 	pluginPath := Find(plugin)
 	if pluginPath == "" {

--- a/pkg/plugin/ipam.go
+++ b/pkg/plugin/ipam.go
@@ -63,10 +63,13 @@ func ExecAdd(plugin string, netconf []byte) (*Result, error) {
 	if os.Getenv("CNI_COMMAND") != "ADD" {
 		return nil, fmt.Errorf("CNI_COMMAND is not ADD")
 	}
+	if plugin == "" {
+		return nil, fmt.Errorf(`Name of IPAM plugin is missing. Specify a "type" field in the "ipam" section`)
+        }
 
 	pluginPath := Find(plugin)
 	if pluginPath == "" {
-		return nil, fmt.Errorf("could not find %q plugin", plugin)
+		return nil, fmt.Errorf("could not find %q IPAM plugin", plugin)
 	}
 
 	stdout := &bytes.Buffer{}


### PR DESCRIPTION
Make it more clear that we failed to find an IPAM plugin.
Check for a missing plugin name and issue a more helpful error.

Fixes #52 
