### PR TITLE
ipvlan/macvlan: remove ipMasq related code

### DIFF
--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -32,7 +32,6 @@ type NetConf struct {
 	plugin.NetConf
 	Master string `json:"master"`
 	Mode   string `json:"mode"`
-	IPMasq bool   `json:"ipMasq"`
 	MTU    int    `json:"mtu"`
 }
 
@@ -136,13 +135,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 	})
 	if err != nil {
 		return err
-	}
-
-	if n.IPMasq {
-		chain := "CNI-" + n.Name
-		if err = ip.SetupIPMasq(ip.Network(&result.IP4.IP), chain); err != nil {
-			return err
-		}
 	}
 
 	return result.Print()

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -32,7 +32,6 @@ type NetConf struct {
 	plugin.NetConf
 	Master string `json:"master"`
 	Mode   string `json:"mode"`
-	IPMasq bool   `json:"ipMasq"`
 	MTU    int    `json:"mtu"`
 }
 
@@ -140,13 +139,6 @@ func cmdAdd(args *skel.CmdArgs) error {
 	})
 	if err != nil {
 		return err
-	}
-
-	if n.IPMasq {
-		chain := "CNI-" + n.Name
-		if err = ip.SetupIPMasq(ip.Network(&result.IP4.IP), chain); err != nil {
-			return err
-		}
 	}
 
 	return result.Print()


### PR DESCRIPTION
Luckily the docs haven't mentioned support for ipMasq for both plugins so far.
Even if anyone has attempted to enable the feature in their configuration files it didn't have the desired effect for the network.

Closes #14.