### PR TITLE
flannel: doc fix and check for missing subnet.env fields

### DIFF
--- a/Documentation/flannel.md
+++ b/Documentation/flannel.md
@@ -4,7 +4,8 @@
 This plugin is designed to work in conjunction with [flannel](https://github.com/coreos/flannel), a network fabric for containers.
 When flannel daemon is started, it outputs a `/run/flannel/subnet.env` file that looks like this:
 ```
-FLANNEL_SUBNET=10.1.17.0/24
+FLANNEL_NETWORK=10.1.0.0/16
+FLANNEL_SUBNET=10.1.17.1/24
 FLANNEL_MTU=1472
 FLANNEL_IPMASQ=true
 ```

--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -48,8 +48,26 @@ type NetConf struct {
 type subnetEnv struct {
 	nw     *net.IPNet
 	sn     *net.IPNet
-	mtu    uint
-	ipmasq bool
+	mtu    *uint
+	ipmasq *bool
+}
+
+func (se *subnetEnv) missing() string {
+	m := []string{}
+
+	if se.nw == nil {
+		m = append(m, "FLANNEL_NETWORK")
+	}
+	if se.sn == nil {
+		m = append(m, "FLANNEL_SUBNET")
+	}
+	if se.mtu == nil {
+		m = append(m, "FLANNEL_MTU")
+	}
+	if se.ipmasq == nil {
+		m = append(m, "FLANNEL_IPMASQ")
+	}
+	return strings.Join(m, ", ")
 }
 
 func loadFlannelNetConf(bytes []byte) (*NetConf, error) {
@@ -92,14 +110,20 @@ func loadFlannelSubnetEnv(fn string) (*subnetEnv, error) {
 			if err != nil {
 				return nil, err
 			}
-			se.mtu = uint(mtu)
+			se.mtu = new(uint)
+			*se.mtu = uint(mtu)
 
 		case "FLANNEL_IPMASQ":
-			se.ipmasq = parts[1] == "true"
+			ipmasq := parts[1] == "true"
+			se.ipmasq = &ipmasq
 		}
 	}
 	if err := s.Err(); err != nil {
 		return nil, err
+	}
+
+	if m := se.missing(); m != "" {
+		return nil, fmt.Errorf("%v is missing %v", fn, m)
 	}
 
 	return se, nil
@@ -182,7 +206,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	if !hasKey(n.Delegate, "ipMasq") {
 		// if flannel is not doing ipmasq, we should
-		ipmasq := !fenv.ipmasq
+		ipmasq := !*fenv.ipmasq
 		n.Delegate["ipMasq"] = ipmasq
 	}
 


### PR DESCRIPTION
- Document that flannel outputs FLANNEL_NETWORK b/c we use it
- Check and error out if expecited fields are missing in subnetEnv file

Fixes #72