### PR TITLE
dhcp: detect if link is down and attempt to set up

### DIFF
--- a/plugins/ipam/dhcp/lease.go
+++ b/plugins/ipam/dhcp/lease.go
@@ -118,6 +118,13 @@ func (l *DHCPLease) acquire() error {
 	}
 	defer c.Close()
 
+	if (l.link.Attrs().Flags & net.FlagUp) != net.FlagUp {
+		log.Printf("Link %q down. Attempting to set up", l.link.Attrs().Name)
+		if err = netlink.LinkSetUp(l.link); err != nil {
+			return err
+		}
+	}
+
 	pkt, err := backoffRetry(func() (*dhcp4.Packet, error) {
 		ok, ack, err := c.Request()
 		switch {


### PR DESCRIPTION
With this we still get the "network is down" error, but after the 2nd
retry the interface is up and the dhcp request works.

Fixes #81.