### PR TITLE
spec: Removed reference to unsupported addIf attribute

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -140,7 +140,6 @@ The network configuration is described in JSON form. The configuration can be st
   "type": "bridge",
   // type (plugin) specific
   "bridge": "cni0",
-  "addIf": "eth0",
   "ipam": {
     "type": "host-local",
     // ipam specific


### PR DESCRIPTION
Removes the "addIf" attribute from the example of a bridge network
definition. This doesn't appear to exist in the implementation.