### PR TITLE
*: add "dns" field to the configuration

### DIFF
--- a/Documentation/ptp.md
+++ b/Documentation/ptp.md
@@ -14,7 +14,11 @@ The traffic of the container interface will be routed through the interface of t
 	"ipam": {
 		"type": "host-local",
 		"subnet": "10.1.1.0/24"
-	}
+	},
+	"dns": [
+		"8.8.8.8",
+		"8.8.4.4"
+	]
 }
 
 ## Network configuration reference
@@ -24,3 +28,4 @@ The traffic of the container interface will be routed through the interface of t
 * `ipMasq` (boolean, optional): set up IP Masquerade on the host for traffic originating from this network and destined outside of it. Defaults to false.
 * `mtu` (integer, optional): explicitly set MTU to the specified value. Defaults to value chosen by the kernel.
 * `ipam` (dictionary, required): IPAM configuration to be used for this network.
+* `dns` (string array, optional): name servers to return as is in the [Result](/SPEC.md#result). Defaults to empty list.

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -67,6 +67,7 @@ type NetConf struct {
 type Result struct {
 	IP4 *IPConfig `json:"ip4,omitempty"`
 	IP6 *IPConfig `json:"ip6,omitempty"`
+	DNS []string  `json:"dns,omitempty"`
 }
 
 func (r *Result) Print() error {

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -35,10 +35,11 @@ const defaultBrName = "cni0"
 
 type NetConf struct {
 	types.NetConf
-	BrName string `json:"bridge"`
-	IsGW   bool   `json:"isGateway"`
-	IPMasq bool   `json:"ipMasq"`
-	MTU    int    `json:"mtu"`
+	BrName string   `json:"bridge"`
+	IsGW   bool     `json:"isGateway"`
+	IPMasq bool     `json:"ipMasq"`
+	MTU    int      `json:"mtu"`
+	DNS    []string `json:"dns"`
 }
 
 func init() {
@@ -226,6 +227,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	result.DNS = n.DNS
 	return result.Print()
 }
 

--- a/plugins/main/ipvlan/ipvlan.go
+++ b/plugins/main/ipvlan/ipvlan.go
@@ -31,9 +31,10 @@ import (
 
 type NetConf struct {
 	types.NetConf
-	Master string `json:"master"`
-	Mode   string `json:"mode"`
-	MTU    int    `json:"mtu"`
+	Master string   `json:"master"`
+	Mode   string   `json:"mode"`
+	MTU    int      `json:"mtu"`
+	DNS    []string `json:"dns"`
 }
 
 func init() {
@@ -138,6 +139,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	result.DNS = n.DNS
 	return result.Print()
 }
 

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -31,9 +31,10 @@ import (
 
 type NetConf struct {
 	types.NetConf
-	Master string `json:"master"`
-	Mode   string `json:"mode"`
-	MTU    int    `json:"mtu"`
+	Master string   `json:"master"`
+	Mode   string   `json:"mode"`
+	MTU    int      `json:"mtu"`
+	DNS    []string `json:"dns"`
 }
 
 func init() {
@@ -142,6 +143,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	result.DNS = n.DNS
 	return result.Print()
 }
 

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -41,8 +41,9 @@ func init() {
 
 type NetConf struct {
 	types.NetConf
-	IPMasq bool `json:"ipMasq"`
-	MTU    int  `json:"mtu"`
+	IPMasq bool     `json:"ipMasq"`
+	MTU    int      `json:"mtu"`
+	DNS    []string `json:"dns"`
 }
 
 func setupContainerVeth(netns, ifName string, mtu int, pr *types.Result) (string, error) {
@@ -185,6 +186,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	result.DNS = conf.DNS
 	return result.Print()
 }
 


### PR DESCRIPTION
appc/cni#76 added a "dns" field in the result JSON. But before this
patch, the plugins had no way of knowing which name server to return.

There could be two ways of knowing which name server to return:
1. add it as an extra argument ("CNI_ARGS")
2. add it in the network configuration as a convenience (received via
   stdin)

I chose the second way because it is easier. In the case of rkt, it
means the user could just add the DNS name servers in
/etc/rkt/net.d/mynetwork.conf.