### PR TITLE
bugfix in LoadArgs

### DIFF
--- a/pkg/types/args.go
+++ b/pkg/types/args.go
@@ -38,7 +38,7 @@ func LoadArgs(args string, container interface{}) error {
 		valueString := kv[1]
 		keyField := containerValue.Elem().FieldByName(keyString)
 		if !keyField.IsValid() {
-			return fmt.Errorf("ARGS: invalid key %q", keyString)
+			continue
 		}
 		u := keyField.Addr().Interface().(encoding.TextUnmarshaler)
 		err := u.UnmarshalText([]byte(valueString))


### PR DESCRIPTION
We should not fail if a given argument doesn't match any interface's
fields name.

Signed-off-by: André Martins <aanm90@gmail.com>