### PR TITLE
MAINTAINERS: remove Eugene from list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,2 @@
-Eugene Yakubovich <eugene.yakubovich@coreos.com> (@eyakubovich)
 Michael Bridgen <michael@weave.works> (@squaremo)
 Stefan Junker <stefan.junker@coreos.com> (@steveeJ)


### PR DESCRIPTION
Eugene is no longer with CoreOS or actively involved with CNI, so remove
him from the current list of maintainers. He'll be gladly welcomed back
if he decides to rejoin the project.