### PR TITLE
Conditionally return allocation from IPAM

### DIFF
--- a/plugins/ipam/host-local/main.go
+++ b/plugins/ipam/host-local/main.go
@@ -54,8 +54,15 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
-	r := &types.Result{
-		IP4: ipConf,
+	r := &types.Result{}
+	if ipConf.IP.IP.To4() != nil {
+		r = &types.Result{
+			IP4: ipConf,
+		}
+	} else {
+		r = &types.Result{
+			IP6: ipConf,
+		}
 	}
 	return r.Print()
 }


### PR DESCRIPTION
Set the ip6 key only if we are doing IPv6 allocation
Closes #131 