### PR TITLE
Add invoke.Delegate{Add,Del} for use by meta-plugins

### DIFF
--- a/pkg/invoke/delegate.go
+++ b/pkg/invoke/delegate.go
@@ -1,0 +1,39 @@
+package invoke
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/appc/cni/pkg/types"
+)
+
+func DelegateAdd(delegatePlugin string, netconf []byte) (*types.Result, error) {
+	if os.Getenv("CNI_COMMAND") != "ADD" {
+		return nil, fmt.Errorf("CNI_COMMAND is not ADD")
+	}
+
+	paths := strings.Split(os.Getenv("CNI_PATH"), ":")
+
+	pluginPath, err := FindInPath(delegatePlugin, paths)
+	if err != nil {
+		return nil, err
+	}
+
+	return ExecPluginWithResult(pluginPath, netconf, ArgsFromEnv())
+}
+
+func DelegateDel(delegatePlugin string, netconf []byte) error {
+	if os.Getenv("CNI_COMMAND") != "DEL" {
+		return fmt.Errorf("CNI_COMMAND is not DEL")
+	}
+
+	paths := strings.Split(os.Getenv("CNI_PATH"), ":")
+
+	pluginPath, err := FindInPath(delegatePlugin, paths)
+	if err != nil {
+		return err
+	}
+
+	return ExecPluginWithoutResult(pluginPath, netconf, ArgsFromEnv())
+}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -17,7 +17,6 @@ package ipam
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/appc/cni/pkg/invoke"
 	"github.com/appc/cni/pkg/ip"
@@ -27,33 +26,11 @@ import (
 )
 
 func ExecAdd(plugin string, netconf []byte) (*types.Result, error) {
-	if os.Getenv("CNI_COMMAND") != "ADD" {
-		return nil, fmt.Errorf("CNI_COMMAND is not ADD")
-	}
-
-	paths := strings.Split(os.Getenv("CNI_PATH"), ":")
-
-	pluginPath, err := invoke.FindInPath(plugin, paths)
-	if err != nil {
-		return nil, err
-	}
-
-	return invoke.ExecPluginWithResult(pluginPath, netconf, invoke.ArgsFromEnv())
+	return invoke.DelegateAdd(plugin, netconf)
 }
 
 func ExecDel(plugin string, netconf []byte) error {
-	if os.Getenv("CNI_COMMAND") != "DEL" {
-		return fmt.Errorf("CNI_COMMAND is not DEL")
-	}
-
-	paths := strings.Split(os.Getenv("CNI_PATH"), ":")
-
-	pluginPath, err := invoke.FindInPath(plugin, paths)
-	if err != nil {
-		return err
-	}
-
-	return invoke.ExecPluginWithoutResult(pluginPath, netconf, invoke.ArgsFromEnv())
+	return invoke.DelegateDel(plugin, netconf)
 }
 
 // ConfigureIface takes the result of IPAM plugin and

--- a/plugins/meta/flannel/flannel.go
+++ b/plugins/meta/flannel/flannel.go
@@ -29,7 +29,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/appc/cni/pkg/ipam"
+	"github.com/appc/cni/pkg/invoke"
 	"github.com/appc/cni/pkg/skel"
 	"github.com/appc/cni/pkg/types"
 )
@@ -155,7 +155,7 @@ func delegateAdd(cid string, netconf map[string]interface{}) error {
 		return err
 	}
 
-	result, err := ipam.ExecAdd(netconf["type"].(string), netconfBytes)
+	result, err := invoke.DelegateAdd(netconf["type"].(string), netconfBytes)
 	if err != nil {
 		return err
 	}
@@ -245,7 +245,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("failed to parse netconf: %v", err)
 	}
 
-	return ipam.ExecDel(n.Type, netconfBytes)
+	return invoke.DelegateDel(n.Type, netconfBytes)
 }
 
 func main() {


### PR DESCRIPTION
The 'flannel' meta plugin delegates to other plugins to do the actual
OS-level work. It used the ipam.Exec{Add,Del} procedures for this
delegation, since those do precisely what's needed.

However this is a bit misleading, since the flannel plugin _isn't_
doing this for IPAM, and the ipam.Exec* procedures aren't doing
something specific to IPAM plugins.

So: anticipating that there may be more meta plugins that want to
delegate in the same way, this commit moves generic delegation
procedures to `pkg/invoke`, and makes the `pkg/ipam` procedures (still
used, accurately, in the non-meta plugins) shims.

See issue #123.