### PR TITLE
macvlan: ARP proxy support

### DIFF
--- a/pkg/util/sysctl/sysctl_linux.go
+++ b/pkg/util/sysctl/sysctl_linux.go
@@ -1,0 +1,58 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// build +linux
+
+package sysctl
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+)
+
+// Sysctl provides a method to set/get values from /proc/sys - in linux systems
+// new interface to set/get values of variables formerly handled by sysctl syscall
+// If optional `params` have only one string value - this function will
+// set this value into coresponding sysctl variable
+func Sysctl(name string, params ...string) (string, error) {
+	if len(params) > 1 {
+		return "", fmt.Errorf("unexcepted additional parameters")
+	} else if len(params) == 1 {
+		return set_sysctl(name, params[0])
+	}
+	return get_sysctl(name)
+}
+
+func get_sysctl(name string) (string, error) {
+	full_name := filepath.Join("/proc/sys", strings.Replace(name, ".", "/", -1))
+	full_name = filepath.Clean(full_name)
+	data, err := ioutil.ReadFile(full_name)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data[:len(data)-1]), nil
+}
+
+func set_sysctl(name, value string) (string, error) {
+	full_name := filepath.Join("/proc/sys", strings.Replace(name, ".", "/", -1))
+	full_name = filepath.Clean(full_name)
+	if err := ioutil.WriteFile(full_name, []byte(value), 0644); err != nil {
+		return "", err
+	}
+
+	return get_sysctl(name)
+}

--- a/plugins/main/macvlan/macvlan.go
+++ b/plugins/main/macvlan/macvlan.go
@@ -26,7 +26,12 @@ import (
 	"github.com/appc/cni/pkg/ns"
 	"github.com/appc/cni/pkg/skel"
 	"github.com/appc/cni/pkg/types"
+	"github.com/appc/cni/pkg/util/sysctl"
 	"github.com/vishvananda/netlink"
+)
+
+const (
+	IPv4InterfaceArpProxySysctlTemplate = "net.ipv4.conf.%s.proxy_arp"
 )
 
 type NetConf struct {
@@ -80,7 +85,7 @@ func createMacvlan(conf *NetConf, ifName string, netns *os.File) error {
 		return fmt.Errorf("failed to lookup master %q: %v", conf.Master, err)
 	}
 
-	// due to kernel bug we have to create with tmpname or it might
+	// due to kernel bug we have to create with tmpName or it might
 	// collide with the name on the host and error out
 	tmpName, err := ip.RandomVethName()
 	if err != nil {
@@ -99,6 +104,14 @@ func createMacvlan(conf *NetConf, ifName string, netns *os.File) error {
 
 	if err := netlink.LinkAdd(mv); err != nil {
 		return fmt.Errorf("failed to create macvlan: %v", err)
+	}
+
+	// TODO: duplicate following lines for ipv6 support, when it will be added in other places
+	ipv4SysctlValueName := fmt.Sprintf(IPv4InterfaceArpProxySysctlTemplate, tmpName)
+	if _, err := sysctl.Sysctl(ipv4SysctlValueName, "1"); err != nil {
+		// remove the newly added link and ignore errors, because we already are in a failed state
+		_ = netlink.LinkDel(mv)
+		return fmt.Errorf("failed to set proxy_arp on newly added interface %q: %v", tmpName, err)
 	}
 
 	return ns.WithNetNS(netns, false, func(_ *os.File) error {


### PR DESCRIPTION
Fixes #84.

--
This PR provides small utility package to operate on sysctl on linux platform (counterpart to similar function in stdlib, but only accessible for *BSD based platforms) used in second patch - which provides proxy_arp setting on newly created macvlan interfaces following description in https://github.com/coreos/rkt/issues/1765

@steveeJ: review request.