### PR TITLE
pkg/skel: add rudimentary unit tests

### DIFF
--- a/pkg/skel/skel_suite_test.go
+++ b/pkg/skel/skel_suite_test.go
@@ -1,0 +1,13 @@
+package skel
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestSkel(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Skel Suite")
+}

--- a/pkg/skel/skel_test.go
+++ b/pkg/skel/skel_test.go
@@ -1,0 +1,61 @@
+package skel
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Skel", func() {
+	var (
+		fNoop = func(_ *CmdArgs) error { return nil }
+		// fErr    = func(_ *CmdArgs) error { return errors.New("dummy") }
+		envVars = []struct {
+			name string
+			val  string
+		}{
+			{"CNI_CONTAINERID", "dummy"},
+			{"CNI_NETNS", "dummy"},
+			{"CNI_IFNAME", "dummy"},
+			{"CNI_ARGS", "dummy"},
+			{"CNI_PATH", "dummy"},
+		}
+	)
+
+	It("Must be possible to set the env vars", func() {
+		for _, v := range envVars {
+			err := os.Setenv(v.name, v.val)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	Context("When dummy environment variables are passed", func() {
+
+		It("should not fail with ADD and noop callback", func() {
+			err := os.Setenv("CNI_COMMAND", "ADD")
+			Expect(err).NotTo(HaveOccurred())
+			PluginMain(fNoop, nil)
+		})
+
+		// TODO: figure out howto mock printing and os.Exit()
+		// It("should fail with ADD and error callback", func() {
+		// 	err := os.Setenv("CNI_COMMAND", "ADD")
+		// 	Expect(err).NotTo(HaveOccurred())
+		// 	PluginMain(fErr, nil)
+		// })
+
+		It("should not fail with DEL and noop callback", func() {
+			err := os.Setenv("CNI_COMMAND", "DEL")
+			Expect(err).NotTo(HaveOccurred())
+			PluginMain(nil, fNoop)
+		})
+
+		// TODO: figure out howto mock printing and os.Exit()
+		// It("should fail with DEL and error callback", func() {
+		// 	err := os.Setenv("CNI_COMMAND", "DEL")
+		// 	Expect(err).NotTo(HaveOccurred())
+		// 	PluginMain(fErr, nil)
+		// })
+	})
+})

--- a/test
+++ b/test
@@ -11,8 +11,8 @@ set -e
 
 source ./build
 
-TESTABLE="plugins/ipam/dhcp plugins/main/loopback pkg/invoke pkg/ns"
-FORMATTABLE="$TESTABLE libcni pkg/ip pkg/ns pkg/types pkg/ipam pkg/skel plugins/ipam/host-local plugins/main/bridge plugins/meta/flannel plugins/meta/tuning"
+TESTABLE="plugins/ipam/dhcp plugins/main/loopback pkg/invoke pkg/ns pkg/skel"
+FORMATTABLE="$TESTABLE libcni pkg/ip pkg/ns pkg/types pkg/ipam plugins/ipam/host-local plugins/main/bridge plugins/meta/flannel plugins/meta/tuning"
 
 # user has not provided PKG override
 if [ -z "$PKG" ]; then


### PR DESCRIPTION
This is an attempt to testing the PluginMain() function of the skel pkg.
We should be able to do better by using a mockable interface for the
plugins, but this is a start.