### PR TITLE
build script: remove the _workspace from GOPATH

### DIFF
--- a/build
+++ b/build
@@ -10,7 +10,7 @@ if [ ! -h gopath/src/${REPO_PATH} ]; then
 fi
 
 export GOBIN=${PWD}/bin
-export GOPATH=${PWD}/gopath:$(pwd)/Godeps/_workspace
+export GOPATH=${PWD}/gopath
 
 echo "Building API"
 go build ${REPO_PATH}/libcni


### PR DESCRIPTION
Missed this when finishing out #156