### PR TITLE
pkg: add a function to generate chain names

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"crypto/sha512"
+	"fmt"
+)
+
+// 29 - len('CNI') - 2*len('-')
+const maxNameLen = 16
+
+// Generates a chain name to be used with iptables.
+// Ensures that the generated name is less than
+// 29 chars in length
+func FormatChainName(name string, id string) string {
+	h := sha512.Sum512([]byte(id))
+	if len(name) > maxNameLen {
+		return fmt.Sprintf("CNI-%s-%x", name[:len(name)-maxNameLen], h[:8])
+	}
+	return fmt.Sprintf("CNI-%s-%x", name, h[:8])
+}

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -1,0 +1,13 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Utils", func() {
+	It("should format a short name", func() {
+		chain := FormatChainName("test", "1234")
+		Expect(chain).To(Equal("CNI-test-d404559f602eab6f"))
+	})
+
+	It("should truncate a long name", func() {
+		chain := FormatChainName("testalongnamethatdoesnotmakesense", "1234")
+		Expect(chain).To(Equal("CNI-testalongnamethat-d404559f602eab6f"))
+	})
+})

--- a/plugins/main/bridge/bridge.go
+++ b/plugins/main/bridge/bridge.go
@@ -28,6 +28,7 @@ import (
 	"github.com/appc/cni/pkg/ns"
 	"github.com/appc/cni/pkg/skel"
 	"github.com/appc/cni/pkg/types"
+	"github.com/appc/cni/pkg/utils"
 	"github.com/vishvananda/netlink"
 )
 
@@ -220,7 +221,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	if n.IPMasq {
-		chain := "CNI-" + n.Name
+		chain := utils.FormatChainName(n.Name, args.ContainerID)
 		if err = ip.SetupIPMasq(ip.Network(&result.IP4.IP), chain); err != nil {
 			return err
 		}

--- a/plugins/main/ptp/ptp.go
+++ b/plugins/main/ptp/ptp.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"crypto/sha512"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,6 +29,7 @@ import (
 	"github.com/appc/cni/pkg/ns"
 	"github.com/appc/cni/pkg/skel"
 	"github.com/appc/cni/pkg/types"
+	"github.com/appc/cni/pkg/utils"
 )
 
 func init() {
@@ -178,8 +178,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	if conf.IPMasq {
-		h := sha512.Sum512([]byte(args.ContainerID))
-		chain := fmt.Sprintf("CNI-%s-%x", conf.Name, h[:8])
+		chain := utils.FormatChainName(conf.Name, args.ContainerID)
 		if err = ip.SetupIPMasq(&result.IP4.IP, chain); err != nil {
 			return err
 		}
@@ -206,8 +205,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	}
 
 	if conf.IPMasq {
-		h := sha512.Sum512([]byte(args.ContainerID))
-		chain := fmt.Sprintf("CNI-%s-%x", conf.Name, h[:8])
+		chain := utils.FormatChainName(conf.Name, args.ContainerID)
 		if err = ip.TeardownIPMasq(ipn, chain); err != nil {
 			return err
 		}

--- a/test
+++ b/test
@@ -11,7 +11,7 @@ set -e
 
 source ./build
 
-TESTABLE="plugins/ipam/dhcp plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types"
+TESTABLE="plugins/ipam/dhcp plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/utils"
 FORMATTABLE="$TESTABLE libcni pkg/ip pkg/ns pkg/types pkg/ipam plugins/ipam/host-local plugins/main/bridge plugins/meta/flannel plugins/meta/tuning"
 
 # user has not provided PKG override


### PR DESCRIPTION
Adds a function to generate chain names for use in iptables and
ports all drivers to use that function. Also adds tests for the
said function.
Fixes https://github.com/coreos/rkt/issues/2314