### PR TITLE
scripts: fix build with go-1.5 after switch to vendor/

### DIFF
--- a/build
+++ b/build
@@ -9,6 +9,7 @@ if [ ! -h gopath/src/${REPO_PATH} ]; then
 	ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
 fi
 
+export GO15VENDOREXPERIMENT=1
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 


### PR DESCRIPTION
go-1.6 enables vendor by default, but go-1.5 needs an environment variable.