### PR TITLE
travis: don't go get vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - GO15VENDOREXPERIMENT=1
 
 install:
- - go get ${TOOLS_CMD}/vet
  - go get ${TOOLS_CMD}/cover
  - go get github.com/modocache/gover
  - go get github.com/mattn/goveralls


### PR DESCRIPTION
The problem:

```
$ go get golang.org/x/tools/cmd/vet
package golang.org/x/tools/cmd/vet: cannot find package "golang.org/x/tools/cmd/vet" in any of:
	/nix/store/4g8l1pw42rnai7m989q61dm65rg2bcqm-go-1.6/share/go/src/golang.org/x/tools/cmd/vet (from $GOROOT)
	/home/steveej/.gopath_1.6_generic/src/golang.org/x/tools/cmd/vet (from $GOPATH)
```