### PR TITLE
Extract and improve test helpers

### DIFF
--- a/pkg/testhelpers/testhelpers.go
+++ b/pkg/testhelpers/testhelpers.go
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// Package testhelpers provides common support behavior for tests
 package testhelpers
 
 import (
@@ -23,6 +25,21 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+func GetInode(path string) (uint64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	return GetInodeF(file)
+}
+
+func GetInodeF(file *os.File) (uint64, error) {
+	stat := &unix.Stat_t{}
+	err := unix.Fstat(int(file.Fd()), stat)
+	return stat.Ino, err
+}
 
 func MakeNetworkNS(containerID string) string {
 	namespace := "/var/run/netns/" + containerID

--- a/pkg/testhelpers/testhelpers.go
+++ b/pkg/testhelpers/testhelpers.go
@@ -1,0 +1,69 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package testhelpers
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func MakeNetworkNS(containerID string) string {
+	namespace := "/var/run/netns/" + containerID
+	pid := unix.Getpid()
+	tid := unix.Gettid()
+
+	err := os.MkdirAll("/var/run/netns", 0600)
+	Expect(err).NotTo(HaveOccurred())
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	go (func() {
+		defer GinkgoRecover()
+
+		err = unix.Unshare(unix.CLONE_NEWNET)
+		Expect(err).NotTo(HaveOccurred())
+
+		fd, err := os.Create(namespace)
+		Expect(err).NotTo(HaveOccurred())
+		defer fd.Close()
+
+		err = unix.Mount("/proc/self/ns/net", namespace, "none", unix.MS_BIND, "")
+		Expect(err).NotTo(HaveOccurred())
+	})()
+
+	Eventually(namespace).Should(BeAnExistingFile())
+
+	fd, err := unix.Open(fmt.Sprintf("/proc/%d/task/%d/ns/net", pid, tid), unix.O_RDONLY, 0)
+	Expect(err).NotTo(HaveOccurred())
+
+	defer unix.Close(fd)
+
+	_, _, e1 := unix.Syscall(unix.SYS_SETNS, uintptr(fd), uintptr(unix.CLONE_NEWNET), 0)
+	Expect(e1).To(BeZero())
+
+	return namespace
+}
+
+func RemoveNetworkNS(networkNS string) error {
+	err := unix.Unmount(networkNS, unix.MNT_DETACH)
+
+	err = os.RemoveAll(networkNS)
+	return err
+}

--- a/pkg/testhelpers/testhelpers_suite_test.go
+++ b/pkg/testhelpers/testhelpers_suite_test.go
@@ -1,0 +1,31 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testhelpers_test
+
+import (
+	"math/rand"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestTesthelpers(t *testing.T) {
+	rand.Seed(config.GinkgoConfig.RandomSeed)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Testhelpers Suite")
+}

--- a/pkg/testhelpers/testhelpers_test.go
+++ b/pkg/testhelpers/testhelpers_test.go
@@ -1,0 +1,96 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testhelpers_test contains unit tests of the testhelpers
+//
+// Some of this stuff is non-trivial and can interact in surprising ways
+// with the Go runtime.  Better be safe.
+package testhelpers_test
+
+import (
+	"fmt"
+	"math/rand"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/appc/cni/pkg/testhelpers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Test helper functions", func() {
+	Describe("MakeNetworkNS", func() {
+		It("should return the filepath to a network namespace", func() {
+			containerID := fmt.Sprintf("c-%x", rand.Int31())
+			nsPath := testhelpers.MakeNetworkNS(containerID)
+
+			Expect(nsPath).To(BeAnExistingFile())
+
+			testhelpers.RemoveNetworkNS(containerID)
+		})
+
+		It("should return a network namespace different from that of the caller", func() {
+			containerID := fmt.Sprintf("c-%x", rand.Int31())
+
+			By("discovering the inode of the current netns")
+			originalNetNSPath := currentNetNSPath()
+			originalNetNSInode, err := testhelpers.GetInode(originalNetNSPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating a new netns")
+			createdNetNSPath := testhelpers.MakeNetworkNS(containerID)
+			defer testhelpers.RemoveNetworkNS(createdNetNSPath)
+
+			By("discovering the inode of the created netns")
+			createdNetNSInode, err := testhelpers.GetInode(createdNetNSPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("comparing the inodes")
+			Expect(createdNetNSInode).NotTo(Equal(originalNetNSInode))
+		})
+
+		It("should not leak the new netns onto any threads in the process", func() {
+			containerID := fmt.Sprintf("c-%x", rand.Int31())
+
+			By("creating a new netns")
+			createdNetNSPath := testhelpers.MakeNetworkNS(containerID)
+			defer testhelpers.RemoveNetworkNS(createdNetNSPath)
+
+			By("discovering the inode of the created netns")
+			createdNetNSInode, err := testhelpers.GetInode(createdNetNSPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("comparing against the netns inode of every thread in the process")
+			for _, netnsPath := range allNetNSInCurrentProcess() {
+				netnsInode, err := testhelpers.GetInode(netnsPath)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(netnsInode).NotTo(Equal(createdNetNSInode))
+			}
+		})
+	})
+})
+
+func currentNetNSPath() string {
+	pid := unix.Getpid()
+	tid := unix.Gettid()
+	return fmt.Sprintf("/proc/%d/task/%d/ns/net", pid, tid)
+}
+
+func allNetNSInCurrentProcess() []string {
+	pid := unix.Getpid()
+	paths, err := filepath.Glob(fmt.Sprintf("/proc/%d/task/*/ns/net", pid))
+	Expect(err).NotTo(HaveOccurred())
+	return paths
+}

--- a/plugins/main/loopback/loopback_suite_test.go
+++ b/plugins/main/loopback/loopback_suite_test.go
@@ -15,18 +15,12 @@
 package main_test
 
 import (
-	"fmt"
-	"os"
-	"runtime"
-
 	"github.com/onsi/gomega/gexec"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"testing"
-
-	"golang.org/x/sys/unix"
 )
 
 var pathToLoPlugin string
@@ -45,47 +39,3 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	gexec.CleanupBuildArtifacts()
 })
-
-func makeNetworkNS(containerID string) string {
-	namespace := "/var/run/netns/" + containerID
-	pid := unix.Getpid()
-	tid := unix.Gettid()
-
-	err := os.MkdirAll("/var/run/netns", 0600)
-	Expect(err).NotTo(HaveOccurred())
-
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	go (func() {
-		defer GinkgoRecover()
-
-		err = unix.Unshare(unix.CLONE_NEWNET)
-		Expect(err).NotTo(HaveOccurred())
-
-		fd, err := os.Create(namespace)
-		Expect(err).NotTo(HaveOccurred())
-		defer fd.Close()
-
-		err = unix.Mount("/proc/self/ns/net", namespace, "none", unix.MS_BIND, "")
-		Expect(err).NotTo(HaveOccurred())
-	})()
-
-	Eventually(namespace).Should(BeAnExistingFile())
-
-	fd, err := unix.Open(fmt.Sprintf("/proc/%d/task/%d/ns/net", pid, tid), unix.O_RDONLY, 0)
-	Expect(err).NotTo(HaveOccurred())
-
-	defer unix.Close(fd)
-
-	_, _, e1 := unix.Syscall(unix.SYS_SETNS, uintptr(fd), uintptr(unix.CLONE_NEWNET), 0)
-	Expect(e1).To(BeZero())
-
-	return namespace
-}
-
-func removeNetworkNS(networkNS string) error {
-	err := unix.Unmount(networkNS, unix.MNT_DETACH)
-
-	err = os.RemoveAll(networkNS)
-	return err
-}

--- a/plugins/main/loopback/loopback_test.go
+++ b/plugins/main/loopback/loopback_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/appc/cni/pkg/ns"
+	"github.com/appc/cni/pkg/testhelpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -39,7 +40,7 @@ var _ = Describe("Loopback", func() {
 	BeforeEach(func() {
 		command = exec.Command(pathToLoPlugin)
 		containerID = "some-container-id"
-		networkNS = makeNetworkNS(containerID)
+		networkNS = testhelpers.MakeNetworkNS(containerID)
 
 		environ = []string{
 			fmt.Sprintf("CNI_CONTAINERID=%s", containerID),
@@ -52,7 +53,7 @@ var _ = Describe("Loopback", func() {
 	})
 
 	AfterEach(func() {
-		Expect(removeNetworkNS(networkNS)).To(Succeed())
+		Expect(testhelpers.RemoveNetworkNS(networkNS)).To(Succeed())
 	})
 
 	Context("when given a network namespace", func() {

--- a/test
+++ b/test
@@ -11,7 +11,7 @@ set -e
 
 source ./build
 
-TESTABLE="plugins/ipam/dhcp plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/utils"
+TESTABLE="plugins/ipam/dhcp plugins/main/loopback pkg/invoke pkg/ns pkg/skel pkg/types pkg/utils pkg/testhelpers"
 FORMATTABLE="$TESTABLE libcni pkg/ip pkg/ns pkg/types pkg/ipam plugins/ipam/host-local plugins/main/bridge plugins/meta/flannel plugins/meta/tuning"
 
 # user has not provided PKG override


### PR DESCRIPTION
As we backfill tests, it is useful to extract a common package of test helpers.

This PR pulls some basic test harness code out of `loopback` and `ns` package test suites and makes them available for other tests.

Because the test helpers contain some non-trivial code (syscalls for `unshare`, `mount`, etc), I've backfilled unit tests of the test helpers themselves.  Those backfilled tests exposed a couple bugs in `MakeNetworkNS`, which I've fixed in the final commit.

You can see the test failures in Travis on the second-to-last commit, and then the fix on the final commit.

Happy to squash those last two if you prefer.
